### PR TITLE
#158304420: Invite user to get authenticated

### DIFF
--- a/client/src/app/components/Center/CenterDetailsComponent.jsx
+++ b/client/src/app/components/Center/CenterDetailsComponent.jsx
@@ -59,6 +59,7 @@ export class CenterDetailsComponent extends React.Component {
     this.onEventSubmitFail = this.onEventSubmitFail.bind(this);
     this.onCenterLoadFail = this.onCenterLoadFail.bind(this);
     this.openEditModal = this.openEditModal.bind(this);
+    this.navToSignin = this.navToSignin.bind(this);
   }
 
   /**
@@ -234,6 +235,14 @@ export class CenterDetailsComponent extends React.Component {
   }
 
   /**
+   * executes after centers have been fetched
+   * @returns { void }
+   */
+  navToSignin() {
+    this.props.history.push('/signin');
+  }
+
+  /**
    * renders component in browser
    * @returns { component } to be rendered on the page
    */
@@ -251,6 +260,7 @@ export class CenterDetailsComponent extends React.Component {
     }
     const canBookCenter = token && !userIsAdmin;
     const canEditCenter = token && userIsAdmin;
+    const response = { status: 401 };
     return (
       <div className="center-detail-page">
         <div className="detail-content">
@@ -352,6 +362,21 @@ export class CenterDetailsComponent extends React.Component {
                             }
                           </tbody>
                         </table>
+                        {
+                          !canBookCenter && !canEditCenter ? (
+                            <React.Fragment>
+                              <hr />
+                              <button
+                                type="button"
+                                className="btn btn-primary btn-lg
+                                btn-block see-more"
+                                onClick={() => this.onEventSubmitFail(response)}
+                              >
+                              Signin to book this center
+                              </button>
+                            </React.Fragment>
+                          ) : null
+                        }
                         {
                           canBookCenter ? (
                             <React.Fragment>

--- a/client/src/app/components/HomePageComponent.jsx
+++ b/client/src/app/components/HomePageComponent.jsx
@@ -166,7 +166,7 @@ export class HomePageComponent extends React.Component {
               <div className="col-md-6 col-lg-4 offset-lg-1 home-page-signup">
                 <div className="card">
                   <div className="card-header">
-                    <h6>Sign up to register events</h6>
+                    <h6>Signup to start booking centers</h6>
                     <div
                       className={this.props.alert ?
                         'form-error' : 'no-visible'}

--- a/client/src/app/components/Sign/SignupComponent.jsx
+++ b/client/src/app/components/Sign/SignupComponent.jsx
@@ -127,7 +127,7 @@ export class SignUpComponent extends React.Component {
               <div className="card">
                 <div className="card-header">
                   <h3>
-                    Sign up to register your events.
+                    Signup to start booking centers.
                     <i
                       className="fa fa-spinner fa-spin hidden"
                       ref={(input) => { this.spinner = input; }}

--- a/client/src/style/index.sass
+++ b/client/src/style/index.sass
@@ -39,8 +39,7 @@ nav
 .top-section
   padding: 50px 0 50px 0
   margin-top: 60px
-  background: url('/images/trans4.jpg')
-  height: calc(100vh - 60px)
+  background: no-repeat url('/images/trans4.jpg')
 
 .submit-button
   margin-top: 20px
@@ -337,6 +336,7 @@ td
 
   .top-section
     padding: 100px 0 100px 0
+    height: calc(100vh - 60px)
 
   .body-section
     .row


### PR DESCRIPTION
#### What does this PR do?
Invite users to get authenticated before they can book centers

#### Description of Task to be completed?
- Change caption on signup forms to invite users to signup before they can book centers
- Create button on center details page linking unauthenticated users to signin before they can book center

#### How should this be manually tested?
- Open a terminal window/tab
- Run `git clone https://github.com/FaithAdekunle/EventsManager.git` to clone the repository.
- cd to the cloned EventsManager folder
- Install dependencies with `npm install`
- run `npm start:dev`
- navigate to `localhost:7777`
- click centers in the navigation bar
- click any of the available centers
- scroll to the bottom of the page

#### What are the relevant pivotal tracker stories? (If applicable)
#158304420